### PR TITLE
fix: depth clearing

### DIFF
--- a/src/Modules/fx/ActiveStream.cpp
+++ b/src/Modules/fx/ActiveStream.cpp
@@ -154,7 +154,7 @@ void ActiveStream::RenderView()
         }
     }
 
-    Interfaces::hlclient->RenderView(view_setup, VIEW_CLEAR_COLOR, RENDERVIEW_DRAWVIEWMODEL | RENDERVIEW_DRAWHUD);
+    Interfaces::hlclient->RenderView(view_setup, VIEW_CLEAR_COLOR | VIEW_CLEAR_DEPTH | VIEW_CLEAR_FULL_TARGET, RENDERVIEW_DRAWVIEWMODEL | RENDERVIEW_DRAWHUD);
 }
 
 void ActiveStream::UpdateMaterials()


### PR DESCRIPTION
i was having issues recording multiple streams at the same time. some examples of issues i was facing:
- when recording one stream with viewmodels on and one stream with viewmodels off, the stream with viewmodels off would sometimes have viewmodels with solid color
- depth stream would sometimes be solid color or smearing
- normal stream would sometimes be solid color or smearing

this patch appears to fix all of these issues. i'm not entirely certain why but it does. also not sure if `VIEW_CLEAR_FULL_TARGET` is strictly necessary